### PR TITLE
Increased torchvision version to 0.19.0

### DIFF
--- a/projects/med_benchmarking/requirements.txt
+++ b/projects/med_benchmarking/requirements.txt
@@ -1,3 +1,3 @@
 timm~=1.0.7
-torchvision~=0.18.0
+torchvision~=0.19.0
 wandb~=0.17.7


### PR DESCRIPTION
# PR Type
Fix

# Short Description
When I install `med_benchmarking` deps with `pip install -r projects/med_benchmarking/requirements.txt`, it installs a lower version of torch (`2.3`) and then runs into dep conflict with `mmlearn`.
This issue is resolved it I we increase torchvision version to 0.19 in the `requirements.txt`

## Reproduce
```bash
# clone mmlearn
git clone git@github.com:VectorInstitute/mmlearn.git

# create virtual env
python3 -m venv my_env
source my_env/bin/activate

# install mmlearn without any extra dependency
cd mmlearn
python3 -m pip install -e .

# install med_benchmarking dependencies
pip install -r projects/med_benchmarking/requirements.txt
```

# Tests Added
None.
