### PR TITLE
Fix handling of `attention_mask` in encoders

### DIFF
--- a/mmlearn/modules/encoders/clip_encoders.py
+++ b/mmlearn/modules/encoders/clip_encoders.py
@@ -327,8 +327,8 @@ class HFCLIPTextEncoderWithProjection(nn.Module):
             The text embeddings. Will be a tuple with a single element.
         """
         input_ids = inputs[Modalities.TEXT]
-        attention_mask = inputs.get("attention_mask") or inputs.get(
-            Modalities.TEXT.attention_mask
+        attention_mask: Optional[torch.Tensor] = inputs.get(
+            "attention_mask", inputs.get(Modalities.TEXT.attention_mask, None)
         )
         position_ids = inputs.get("position_ids")
 
@@ -568,8 +568,9 @@ class PubMedBERTForCLIPTextEncoding(nn.Module):
         """
         output = self.model(
             input_ids=inputs[Modalities.TEXT],
-            attention_mask=inputs.get("attention_mask")
-            or inputs.get(Modalities.TEXT.attention_mask),
+            attention_mask=inputs.get(
+                "attention_mask", inputs.get(Modalities.TEXT.attention_mask, None)
+            ),
             inputs_embeds=inputs.get("inputs_embeds"),
             output_attentions=inputs.get("output_attentions"),
             output_hidden_states=True,

--- a/mmlearn/modules/encoders/hf_text_encoders.py
+++ b/mmlearn/modules/encoders/hf_text_encoders.py
@@ -156,8 +156,9 @@ class HFTextEncoder(nn.Module):
         """
         outputs = self.model(
             input_ids=inputs[Modalities.TEXT],
-            attention_mask=inputs.get("attention_mask")
-            or inputs.get(Modalities.TEXT.attention_mask),
+            attention_mask=inputs.get(
+                "attention_mask", inputs.get(Modalities.TEXT.attention_mask, None)
+            ),
             position_ids=inputs.get("position_ids"),
             output_attentions=inputs.get("output_attentions"),
             return_dict=True,

--- a/projects/bioscan_clip/encoders.py
+++ b/projects/bioscan_clip/encoders.py
@@ -140,8 +140,9 @@ class BarcodeBERT(nn.Module):
         """Run the forward pass."""
         outputs = self.model(
             input_ids=inputs[Modalities.DNA],
-            attention_mask=inputs.get("attention_mask")
-            or inputs.get(Modalities.DNA.attention_mask),
+            attention_mask=inputs.get(
+                "attention_mask", inputs.get(Modalities.DNA.attention_mask, None)
+            ),
             position_ids=inputs.get("position_ids"),
             output_attentions=inputs.get("output_attentions"),
             return_dict=True,


### PR DESCRIPTION
# PR Type
Fix

# Short Description

- When `inputs.get("attention_mask")` is not None (i.e. a Tensor), an error will be raised because `Tensor or inputs.get(Modalities.TEXT.attention_mask)` cannot be evaluated.

# Tests Added
...
