### PR TITLE
Refactor modality object

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ experimentation and research for new techniques.
 ## Quick Start
 ### Installation
 #### Prerequisites
-The library requires Python 3.9 or later. We recommend using a virtual environment to manage dependencies. You can create
+The library requires Python 3.10 or later. We recommend using a virtual environment to manage dependencies. You can create
 a virtual environment using the following command:
 ```bash
 python3 -m venv /path/to/new/virtual/environment

--- a/mmlearn/conf/__init__.py
+++ b/mmlearn/conf/__init__.py
@@ -1,6 +1,7 @@
 """Hydra/Hydra-zen-based configurations."""
 
 import functools
+import os
 import warnings
 from dataclasses import dataclass, field
 from enum import Enum
@@ -29,7 +30,7 @@ from mmlearn.datasets.core.data_collator import DefaultDataCollator
 
 def _get_default_ckpt_dir() -> Any:
     """Get the default checkpoint directory."""
-    return SI("/checkpoint/${oc.env:USER}/${oc.env:SLURM_JOB_ID}")
+    return SI("${hydra:runtime.output_dir}/checkpoints")
 
 
 _DataLoaderConf = builds(

--- a/mmlearn/datasets/chexpert.py
+++ b/mmlearn/datasets/chexpert.py
@@ -105,7 +105,7 @@ class CheXpert(Dataset[Example]):
 
         return Example(
             {
-                Modalities.RGB: image,
+                Modalities.RGB.name: image,
                 Modalities.RGB.target: label,
                 "qid": entry["qid"],
                 EXAMPLE_INDEX_KEY: idx,

--- a/mmlearn/datasets/core/data_collator.py
+++ b/mmlearn/datasets/core/data_collator.py
@@ -2,12 +2,12 @@
 
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable, Optional
 
 from torch.utils.data import default_collate
 
 from mmlearn.datasets.core.example import Example
-from mmlearn.datasets.core.modalities import Modalities, Modality
+from mmlearn.datasets.core.modalities import Modalities
 
 
 @dataclass
@@ -43,9 +43,9 @@ class DefaultDataCollator:
 
         if self.batch_processors is not None:
             for key, processor in self.batch_processors.items():
-                batch_key: Union[str, Modality] = key
+                batch_key: str = key
                 if Modalities.has_modality(key):
-                    batch_key = Modalities.get_modality(key)
+                    batch_key = Modalities.get_modality(key).name
 
                 if batch_key in batch:
                     batch_processed = processor(batch[batch_key])

--- a/mmlearn/datasets/imagenet.py
+++ b/mmlearn/datasets/imagenet.py
@@ -58,7 +58,7 @@ class ImageNet(ImageFolder):
         image, target = super().__getitem__(index)
         example = Example(
             {
-                Modalities.RGB: image,
+                Modalities.RGB.name: image,
                 Modalities.RGB.target: target,
                 EXAMPLE_INDEX_KEY: index,
             }

--- a/mmlearn/datasets/librispeech.py
+++ b/mmlearn/datasets/librispeech.py
@@ -108,8 +108,8 @@ class LibriSpeech(Dataset[Example]):
 
         return Example(
             {
-                Modalities.AUDIO: waveform,
-                Modalities.TEXT: transcript,
+                Modalities.AUDIO.name: waveform,
+                Modalities.TEXT.name: transcript,
                 EXAMPLE_INDEX_KEY: idx,
             },
         )

--- a/mmlearn/datasets/llvip.py
+++ b/mmlearn/datasets/llvip.py
@@ -70,10 +70,10 @@ class LLVIPDataset(Dataset[Example]):
         rgb_image = PILImage.open(rgb_image_path).convert("RGB")
         ir_image = PILImage.open(ir_image_path).convert("L")
 
-        sample = Example(
+        example = Example(
             {
-                Modalities.RGB: self.transform(rgb_image),
-                Modalities.THERMAL: self.transform(ir_image),
+                Modalities.RGB.name: self.transform(rgb_image),
+                Modalities.THERMAL.name: self.transform(ir_image),
                 EXAMPLE_INDEX_KEY: idx,
             },
         )
@@ -85,11 +85,11 @@ class LLVIPDataset(Dataset[Example]):
                 .replace("train", "")
             )
             annot = self._get_bbox(annot_path)
-            sample["annotation"] = {
+            example["annotation"] = {
                 "bboxes": torch.from_numpy(annot["bboxes"]),
                 "labels": torch.from_numpy(annot["labels"]),
             }
-        return sample
+        return example
 
     def _get_bbox(self, filename: str) -> Dict[str, np.ndarray]:
         """Parse the XML file to get bounding boxes and labels.

--- a/mmlearn/datasets/nihcxr.py
+++ b/mmlearn/datasets/nihcxr.py
@@ -95,7 +95,7 @@ class NIHCXR(Dataset[Example]):
 
         example = Example(
             {
-                Modalities.RGB: image,
+                Modalities.RGB.name: image,
                 Modalities.RGB.target: label,
                 "qid": entry["qid"],
                 EXAMPLE_INDEX_KEY: idx,

--- a/mmlearn/datasets/nyuv2.py
+++ b/mmlearn/datasets/nyuv2.py
@@ -201,8 +201,8 @@ class NYUv2Dataset(Dataset[Example]):
 
         return Example(
             {
-                Modalities.RGB: rgb_image,
-                Modalities.DEPTH: depth_image,
+                Modalities.RGB.name: rgb_image,
+                Modalities.DEPTH.name: depth_image,
                 EXAMPLE_INDEX_KEY: idx,
                 Modalities.DEPTH.target: self.samples[idx][2],
             }

--- a/mmlearn/datasets/processors/tokenizers.py
+++ b/mmlearn/datasets/processors/tokenizers.py
@@ -86,7 +86,7 @@ class HFTokenizer:
                     batch_encoding[key] = torch.squeeze(value, 0)
 
         # use 'Modalities.TEXT' key for input_ids for consistency
-        batch_encoding[Modalities.TEXT] = batch_encoding["input_ids"]
+        batch_encoding[Modalities.TEXT.name] = batch_encoding["input_ids"]
         return dict(batch_encoding)
 
 

--- a/mmlearn/datasets/sunrgbd.py
+++ b/mmlearn/datasets/sunrgbd.py
@@ -261,8 +261,8 @@ class SUNRGBDDataset(Dataset[Example]):
 
         return Example(
             {
-                Modalities.RGB: rgb_image,
-                Modalities.DEPTH: depth_image,
+                Modalities.RGB.name: rgb_image,
+                Modalities.DEPTH.name: depth_image,
                 EXAMPLE_INDEX_KEY: idx,
                 Modalities.DEPTH.target: self.samples[idx][2],
             }

--- a/mmlearn/modules/encoders/clip.py
+++ b/mmlearn/modules/encoders/clip.py
@@ -12,7 +12,6 @@ from transformers.modeling_outputs import BaseModelOutput
 
 from mmlearn import hf_utils
 from mmlearn.datasets.core import Modalities
-from mmlearn.datasets.core.modalities import Modality
 from mmlearn.modules.layers import PatchDropout
 
 
@@ -87,12 +86,12 @@ class HFCLIPTextEncoder(nn.Module):
         self.model = model
         self.pooling_layer = pooling_layer
 
-    def forward(self, inputs: Dict[Union[str, Modality], Any]) -> BaseModelOutput:
+    def forward(self, inputs: Dict[str, Any]) -> BaseModelOutput:
         """Run the forward pass.
 
         Parameters
         ----------
-        inputs : Dict[str | Modality, Any]
+        inputs : Dict[str, Any]
             The input data. The `input_ids` will be expected under the `Modalities.TEXT`
             key.
 
@@ -103,7 +102,7 @@ class HFCLIPTextEncoder(nn.Module):
             and the attention weights, if `output_attentions` is set to `True`.
         """
         outputs = self.model(
-            input_ids=inputs[Modalities.TEXT],
+            input_ids=inputs[Modalities.TEXT.name],
             attention_mask=inputs.get("attention_mask")
             or inputs.get(Modalities.TEXT.attention_mask),
             position_ids=inputs.get("position_ids"),
@@ -203,12 +202,12 @@ class HFCLIPVisionEncoder(nn.Module):
                 bias=patch_dropout_bias,
             )
 
-    def forward(self, inputs: Dict[Union[str, Modality], Any]) -> BaseModelOutput:
+    def forward(self, inputs: Dict[str, Any]) -> BaseModelOutput:
         """Run the forward pass.
 
         Parameters
         ----------
-        inputs : Dict[str | Modality, Any]
+        inputs : Dict[str, Any]
             The input data. The image tensor will be expected under the `Modalities.RGB`
             key.
 
@@ -220,7 +219,7 @@ class HFCLIPVisionEncoder(nn.Module):
 
         """
         # FIXME: handle other vision modalities
-        pixel_values = inputs[Modalities.RGB]
+        pixel_values = inputs[Modalities.RGB.name]
         hidden_states = self.model.embeddings(pixel_values)
         if self.patch_dropout is not None:
             hidden_states = self.patch_dropout(hidden_states)
@@ -312,12 +311,12 @@ class HFCLIPTextEncoderWithProjection(nn.Module):
 
         self.model = model
 
-    def forward(self, inputs: Dict[Union[str, Modality], Any]) -> Tuple[torch.Tensor]:
+    def forward(self, inputs: Dict[str, Any]) -> Tuple[torch.Tensor]:
         """Run the forward pass.
 
         Parameters
         ----------
-        inputs : Dict[str | Modality, Any]
+        inputs : Dict[str, Any]
             The input data. The `input_ids` will be expected under the `Modalities.TEXT`
             key.
 
@@ -326,7 +325,7 @@ class HFCLIPTextEncoderWithProjection(nn.Module):
         Tuple[torch.Tensor]
             The text embeddings. Will be a tuple with a single element.
         """
-        input_ids = inputs[Modalities.TEXT]
+        input_ids = inputs[Modalities.TEXT.name]
         attention_mask: Optional[torch.Tensor] = inputs.get(
             "attention_mask", inputs.get(Modalities.TEXT.attention_mask, None)
         )
@@ -436,7 +435,7 @@ class HFCLIPVisionEncoderWithProjection(nn.Module):
                 bias=patch_dropout_bias,
             )
 
-    def forward(self, inputs: Dict[Union[str, Modality], Any]) -> Tuple[torch.Tensor]:
+    def forward(self, inputs: Dict[str, Any]) -> Tuple[torch.Tensor]:
         """Run the forward pass.
 
         Parameters
@@ -450,7 +449,7 @@ class HFCLIPVisionEncoderWithProjection(nn.Module):
         Tuple[torch.Tensor]
             The image embeddings. Will be a tuple with a single element.
         """
-        pixel_values = inputs[Modalities.RGB]
+        pixel_values = inputs[Modalities.RGB.name]
         hidden_states = self.model.vision_model.embeddings(pixel_values)
         if self.patch_dropout is not None:
             hidden_states = self.patch_dropout(hidden_states)
@@ -551,12 +550,12 @@ class PubMedBERTForCLIPTextEncoding(nn.Module):
         self.model = model
         self.pooling_layer = pooling_layer
 
-    def forward(self, inputs: Dict[Union[str, Modality], Any]) -> BaseModelOutput:
+    def forward(self, inputs: Dict[str, Any]) -> BaseModelOutput:
         """Run the forward pass.
 
         Parameters
         ----------
-        inputs : Dict[str | Modality, Any]
+        inputs : Dict[str, Any]
             The input data. The `input_ids` will be expected under the `Modalities.TEXT`
             key.
 
@@ -567,7 +566,7 @@ class PubMedBERTForCLIPTextEncoding(nn.Module):
             and the attention weights, if `output_attentions` is set to `True`.
         """
         output = self.model(
-            input_ids=inputs[Modalities.TEXT],
+            input_ids=inputs[Modalities.TEXT.name],
             attention_mask=inputs.get(
                 "attention_mask", inputs.get(Modalities.TEXT.attention_mask, None)
             ),

--- a/mmlearn/modules/encoders/text.py
+++ b/mmlearn/modules/encoders/text.py
@@ -10,7 +10,6 @@ from transformers.modeling_outputs import BaseModelOutput
 
 from mmlearn import hf_utils
 from mmlearn.datasets.core import Modalities
-from mmlearn.datasets.core.modalities import Modality
 
 
 if TYPE_CHECKING:
@@ -139,12 +138,12 @@ class HFTextEncoder(nn.Module):
         self.model = model
         self.pooling_layer = pooling_layer
 
-    def forward(self, inputs: Dict[Union[str, Modality], Any]) -> BaseModelOutput:
+    def forward(self, inputs: Dict[str, Any]) -> BaseModelOutput:
         """Run the forward pass.
 
         Parameters
         ----------
-        inputs : Dict[str | Modality, Any]
+        inputs : Dict[str, Any]
             The input data. The `input_ids` will be expected under the `Modalities.TEXT`
             key.
 
@@ -155,7 +154,7 @@ class HFTextEncoder(nn.Module):
             and the attention weights, if `output_attentions` is set to `True`.
         """
         outputs = self.model(
-            input_ids=inputs[Modalities.TEXT],
+            input_ids=inputs[Modalities.TEXT.name],
             attention_mask=inputs.get(
                 "attention_mask", inputs.get(Modalities.TEXT.attention_mask, None)
             ),

--- a/mmlearn/modules/encoders/vision.py
+++ b/mmlearn/modules/encoders/vision.py
@@ -113,12 +113,12 @@ class TimmViT(nn.Module):
                             (not freeze_layer_norm) if "norm" in name else False
                         )
 
-    def forward(self, inputs: Dict[Union[str, Modality], Any]) -> BaseModelOutput:
+    def forward(self, inputs: Dict[str, Any]) -> BaseModelOutput:
         """Run the forward pass.
 
         Parameters
         ----------
-        inputs : Dict[str | Modality, Any]
+        inputs : Dict[str, Any]
             The input data. The `image` will be expected under the `Modalities.RGB` key.
 
         Returns
@@ -126,7 +126,7 @@ class TimmViT(nn.Module):
         BaseModelOutput
             The output of the model.
         """
-        x = inputs[Modalities.RGB]
+        x = inputs[Modalities.RGB.name]
         last_hidden_state, hidden_states = self.model.forward_intermediates(
             x, output_fmt="NLC"
         )

--- a/mmlearn/tasks/hooks.py
+++ b/mmlearn/tasks/hooks.py
@@ -19,11 +19,7 @@ class EvaluationHooks:
         """
 
     def evaluation_step(
-        self,
-        trainer: pl.Trainer,
-        pl_module: pl.LightningModule,
-        batch: Any,
-        batch_idx: int,
+        self, pl_module: pl.LightningModule, batch: Any, batch_idx: int
     ) -> Optional[Mapping[str, Any]]:
         """Run a single evaluation step.
 

--- a/projects/bioscan_clip/README.md
+++ b/projects/bioscan_clip/README.md
@@ -59,7 +59,7 @@ environment, remove the `hydra.launcher.*` arguments.
 ### Evaluation
 To run taxonomic classification evaluation task on the BIOSCAN-1M dataset, use the following command:
 ```bash
-mmlearn_run 'hydra.searchpath=[pkg://projects.bioscan_clip.configs]' +experiment=bioscan_1m experiment_name=bioscan1m_eval job_type=eval resume_from_checkpoint=<path_to_checkpoint> strict_loading=false trainer.devices=1
+mmlearn_run 'hydra.searchpath=[pkg://projects.bioscan_clip.configs]' +experiment=bioscan_1m experiment_name=bioscan1m_eval job_type=eval resume_from_checkpoint=<path_to_checkpoint> trainer.devices=1
 ```
 
 <details>

--- a/projects/bioscan_clip/configs/experiment/bioscan_1m.yaml
+++ b/projects/bioscan_clip/configs/experiment/bioscan_1m.yaml
@@ -112,6 +112,7 @@ trainer:
       save_top_k: 1
       save_last: True
       every_n_epochs: 1
+      dirpath: /checkpoint/${oc.env:USER}/${oc.env:SLURM_JOB_ID} # only works on Vector SLURM environment
     model_summary:
       max_depth: 2
 

--- a/projects/bioscan_clip/dataset.py
+++ b/projects/bioscan_clip/dataset.py
@@ -159,9 +159,9 @@ class BIOSCANInsectDataset(Dataset[Example]):
         return Example(
             {
                 EXAMPLE_INDEX_KEY: idx,
-                Modalities.RGB: image,
-                Modalities.DNA: dna_seq,
-                Modalities.TEXT: language_input_ids,
+                Modalities.RGB.name: image,
+                Modalities.DNA.name: dna_seq,
+                Modalities.TEXT.name: language_input_ids,
                 "language_token_type_ids": language_token_type_ids,
                 Modalities.TEXT.attention_mask: language_attention_mask,
                 "labels": self.labels[idx],

--- a/projects/bioscan_clip/encoders.py
+++ b/projects/bioscan_clip/encoders.py
@@ -76,10 +76,10 @@ class BarcodeBERT(nn.Module):
         if peft_config is not None:
             self.model = hf_utils._wrap_peft_model(self.model, peft_config)
 
-    def forward(self, inputs: Dict[Union[str, Modality], Any]) -> BaseModelOutput:
+    def forward(self, inputs: Dict[str, Any]) -> BaseModelOutput:
         """Run the forward pass."""
         outputs = self.model(
-            input_ids=inputs[Modalities.DNA],
+            input_ids=inputs[Modalities.DNA.name],
             attention_mask=inputs.get(
                 "attention_mask", inputs.get(Modalities.DNA.attention_mask, None)
             ),

--- a/projects/med_benchmarking/README.md
+++ b/projects/med_benchmarking/README.md
@@ -34,5 +34,5 @@ mmlearn_run --multirun hydra.launcher.mem_gb=32 hydra.launcher.qos=your_qos hydr
 
 To run zero-shot retrieval evaluation on a pretrained model locally (on the ROCO dataset, as an example), use the following command:
 ```bash
-mmlearn_run 'hydra.searchpath=[pkg://projects.med_benchmarking.configs]' +experiment=baseline job_type=eval +datasets@datasets.test=ROCO datasets.test.split=test +datasets/tokenizers@dataloader.test.collate_fn.batch_processors.text=HFCLIPTokenizer +datasets/transforms@datasets.test.transform=med_clip_vision_transform datasets.test.transform.job_type=eval dataloader.test.batch_size=32 dataloader.test.num_workers=2 strict_loading=False resume_from_checkpoint=/path/to/your/checkpoint experiment_name=test
+mmlearn_run 'hydra.searchpath=[pkg://projects.med_benchmarking.configs]' +experiment=baseline job_type=eval +datasets@datasets.test=ROCO datasets.test.split=test +datasets/tokenizers@dataloader.test.collate_fn.batch_processors.text=HFCLIPTokenizer +datasets/transforms@datasets.test.transform=med_clip_vision_transform datasets.test.transform.job_type=eval dataloader.test.batch_size=32 dataloader.test.num_workers=2 resume_from_checkpoint=/path/to/your/checkpoint experiment_name=test
 ```

--- a/projects/med_benchmarking/configs/__init__.py
+++ b/projects/med_benchmarking/configs/__init__.py
@@ -65,14 +65,23 @@ def med_clip_vision_transform(
     transforms.Compose
         Composed transforms for training CLIP with medical images.
     """
+    if job_type == "train":
+        return transforms.Compose(
+            [
+                ResizeKeepRatio(512, interpolation="bicubic"),
+                transforms.RandomCrop(image_crop_size),
+                transforms.ToTensor(),
+                transforms.Normalize(
+                    mean=[0.48145466, 0.4578275, 0.40821073],
+                    std=[0.26862954, 0.26130258, 0.27577711],
+                ),
+            ]
+        )
+
     return transforms.Compose(
         [
-            ResizeKeepRatio(
-                512 if job_type == "train" else image_crop_size, interpolation="bicubic"
-            ),
-            transforms.RandomCrop(image_crop_size)
-            if job_type == "train"
-            else transforms.CenterCrop(image_crop_size),
+            ResizeKeepRatio(image_crop_size, interpolation="bicubic"),
+            transforms.CenterCrop(image_crop_size),
             transforms.ToTensor(),
             transforms.Normalize(
                 mean=[0.48145466, 0.4578275, 0.40821073],

--- a/projects/med_benchmarking/configs/experiment/baseline.yaml
+++ b/projects/med_benchmarking/configs/experiment/baseline.yaml
@@ -100,6 +100,7 @@ trainer:
       save_top_k: 1
       save_last: True
       every_n_epochs: 1
+      dirpath: /checkpoint/${oc.env:USER}/${oc.env:SLURM_JOB_ID} # only works on Vector SLURM environment
     early_stopping:
       monitor: val/loss
       patience: 5

--- a/projects/med_benchmarking/datasets/medvqa.py
+++ b/projects/med_benchmarking/datasets/medvqa.py
@@ -176,8 +176,8 @@ class MedVQA(Dataset[Example]):
 
         example = Example(
             {
-                Modalities.TEXT: question,
-                Modalities.RGB: image_data,
+                Modalities.TEXT.name: question,
+                Modalities.RGB.name: image_data,
                 EXAMPLE_INDEX_KEY: index,
                 "qid": entry["qid"],
                 "answer_type": entry["answer_type"],

--- a/projects/med_benchmarking/datasets/mimiciv_cxr.py
+++ b/projects/med_benchmarking/datasets/mimiciv_cxr.py
@@ -138,7 +138,7 @@ class MIMICIVCXR(Dataset):
         ) as img:
             image = self.transform(img.convert("RGB"))
 
-        example = Example({Modalities.RGB: image, EXAMPLE_INDEX_KEY: idx})
+        example = Example({Modalities.RGB.name: image, EXAMPLE_INDEX_KEY: idx})
 
         if self._labeler in ["negbio", "chexpert"]:
             example["subject_id"] = entry["subject_id"]
@@ -154,18 +154,18 @@ class MIMICIVCXR(Dataset):
                 if tokenized_report is not None:
                     example[Modalities.TEXT] = tokenized_report
         else:
-            example[Modalities.TEXT] = entry["caption"]
+            example[Modalities.TEXT.name] = entry["caption"]
             tokens = (
                 self.tokenizer(entry["caption"]) if self.tokenizer is not None else None
             )
             if tokens is not None:
                 if isinstance(tokens, dict):  # output of HFTokenizer
                     assert (
-                        Modalities.TEXT in tokens
-                    ), f"Missing key `{Modalities.TEXT}` in tokens."
+                        Modalities.TEXT.name in tokens
+                    ), f"Missing key `{Modalities.TEXT.name}` in tokens."
                     example.update(tokens)
                 else:
-                    example[Modalities.TEXT] = tokens
+                    example[Modalities.TEXT.name] = tokens
 
         return example
 

--- a/projects/med_benchmarking/datasets/pmcoa.py
+++ b/projects/med_benchmarking/datasets/pmcoa.py
@@ -114,8 +114,8 @@ class PMCOA(Dataset[Example]):
         caption = self.captions[idx].as_py()
         example = Example(
             {
-                Modalities.RGB: images,
-                Modalities.TEXT: caption,
+                Modalities.RGB.name: images,
+                Modalities.TEXT.name: caption,
                 EXAMPLE_INDEX_KEY: idx,
             }
         )
@@ -124,11 +124,11 @@ class PMCOA(Dataset[Example]):
         if tokens is not None:
             if isinstance(tokens, dict):  # output of HFTokenizer
                 assert (
-                    Modalities.TEXT in tokens
-                ), f"Missing key `{Modalities.TEXT}` in tokens."
+                    Modalities.TEXT.name in tokens
+                ), f"Missing key `{Modalities.TEXT.name}` in tokens."
                 example.update(tokens)
             else:
-                example[Modalities.TEXT] = tokens
+                example[Modalities.TEXT.name] = tokens
 
         if self.mask_generator is not None and self.tokenizer is not None:
             _, masked_labels, masked_text = self.mask_generator(

--- a/projects/med_benchmarking/datasets/quilt.py
+++ b/projects/med_benchmarking/datasets/quilt.py
@@ -146,8 +146,8 @@ class Quilt(Dataset[Example]):
 
         example = Example(
             {
-                Modalities.RGB: image,
-                Modalities.TEXT: caption,
+                Modalities.RGB.name: image,
+                Modalities.TEXT.name: caption,
                 EXAMPLE_INDEX_KEY: idx,
                 "qid": self.data_df.index[idx],
                 "magnification": self.data_df.loc[idx, "magnification"],
@@ -159,11 +159,11 @@ class Quilt(Dataset[Example]):
         if tokens is not None:
             if isinstance(tokens, dict):  # output of HFTokenizer
                 assert (
-                    Modalities.TEXT in tokens
-                ), f"Missing key `{Modalities.TEXT}` in tokens."
+                    Modalities.TEXT.name in tokens
+                ), f"Missing key `{Modalities.TEXT.name}` in tokens."
                 example.update(tokens)
             else:
-                example[Modalities.TEXT] = tokens
+                example[Modalities.TEXT.name] = tokens
 
         return example
 

--- a/projects/med_benchmarking/datasets/roco.py
+++ b/projects/med_benchmarking/datasets/roco.py
@@ -92,8 +92,8 @@ class ROCO(Dataset[Example]):
 
         example = Example(
             {
-                Modalities.RGB: image,
-                Modalities.TEXT: caption,
+                Modalities.RGB.name: image,
+                Modalities.TEXT.name: caption,
                 EXAMPLE_INDEX_KEY: idx,
             }
         )
@@ -101,11 +101,11 @@ class ROCO(Dataset[Example]):
         if tokens is not None:
             if isinstance(tokens, dict):  # output of HFTokenizer
                 assert (
-                    Modalities.TEXT in tokens
-                ), f"Missing key `{Modalities.TEXT}` in tokens."
+                    Modalities.TEXT.name in tokens
+                ), f"Missing key `{Modalities.TEXT.name}` in tokens."
                 example.update(tokens)
             else:
-                example[Modalities.TEXT] = tokens
+                example[Modalities.TEXT.name] = tokens
 
         return example
 

--- a/tests/datasets/test_masking.py
+++ b/tests/datasets/test_masking.py
@@ -23,7 +23,7 @@ def test_random_masking() -> None:
     )
 
     torch.testing.assert_close(
-        tokenizer_output[Modalities.TEXT][:4], torch.tensor([0, 250, 1345, 9])
+        tokenizer_output[Modalities.TEXT.name][:4], torch.tensor([0, 250, 1345, 9])
     )
 
     _, _, mask = mask_generator(

--- a/tests/datasets/test_modality.py
+++ b/tests/datasets/test_modality.py
@@ -1,0 +1,111 @@
+"""Test modality registry and related classes."""
+
+import pytest
+
+from mmlearn.datasets.core.modalities import Modality, ModalityRegistry
+
+
+def test_modality_init():
+    """Test modality initialization."""
+    modality = Modality("text")
+    assert modality.name == "text"
+    assert modality.target == "text_target"
+    assert modality.mask == "text_mask"
+    assert modality.embedding == "text_embedding"
+    assert modality.masked_embedding == "text_masked_embedding"
+    assert modality.ema_embedding == "text_ema_embedding"
+
+    for name, property_name in modality.properties.items():
+        assert getattr(modality, name) == property_name
+
+    assert str(modality) == "text"
+
+
+def test_modality_init_with_custom_properties():
+    """Test modality initialization with custom properties."""
+    modality = Modality("text", {"a_custom_property": "{}_custom_value"})
+    assert modality.a_custom_property == "text_custom_value"
+    assert "a_custom_property" in modality.properties
+
+
+def test_modality_add_property():
+    """Test modality add property."""
+    modality = Modality("text")
+    modality.add_property("a_custom_property", "{}_custom_value")
+    assert modality.a_custom_property == "text_custom_value"
+
+    with pytest.warns(UserWarning):
+        modality.add_property("a_custom_property", "{}_custom_value2")
+    assert modality.a_custom_property == "text_custom_value2"
+
+    with pytest.raises(ValueError):
+        modality.add_property("a_custom_property_2", "custom_value")
+
+
+def test_modality_registry_singleton():
+    """Test modality registry singleton."""
+    registry1 = ModalityRegistry()
+    registry2 = ModalityRegistry()
+    assert registry1 is registry2
+
+
+def test_modality_registration():
+    """Test modality registration."""
+    registry = ModalityRegistry()
+    registry.register_modality("modality_name")
+    assert "modality_name" in registry._modality_registry
+    assert registry.has_modality("modality_name")
+
+    modality = registry.get_modality("modality_name")
+    assert isinstance(modality, Modality)
+    assert modality.name == "modality_name"
+    assert sorted(modality.properties) == sorted(
+        [
+            "target",
+            "mask",
+            "embedding",
+            "masked_embedding",
+            "ema_embedding",
+            "attention_mask",
+        ]
+    )
+
+    # check attribute access
+    assert registry.modality_name.target == "modality_name_target"
+    assert registry.modality_name.attention_mask == "modality_name_attention_mask"
+    assert registry.modality_name.mask == "modality_name_mask"
+    assert registry.modality_name.embedding == "modality_name_embedding"
+    assert registry.modality_name.masked_embedding == "modality_name_masked_embedding"
+    assert registry.modality_name.ema_embedding == "modality_name_ema_embedding"
+
+    # check list_modalities
+    assert registry.list_modalities()[-1] == modality
+
+    # check registration with same name overwrites the existing modality
+    with pytest.warns(UserWarning):
+        registry.register_modality(
+            "modality_name", {"a_custom_property": "{}_custom_value"}
+        )
+    assert registry.modality_name.a_custom_property == "modality_name_custom_value"
+
+    # check addition of modality specific properties
+
+
+def test_modality_registration_with_custom_properties():
+    """Test modality registration with custom properties."""
+    registry = ModalityRegistry()
+    registry.register_modality(
+        "modality_name_2", {"a_custom_property": "{}_custom_value"}
+    )
+    modality = registry.get_modality("modality_name_2")
+    assert modality.name == "modality_name_2"
+    assert modality.a_custom_property == "modality_name_2_custom_value"
+
+
+def test_modality_registration_with_invalid_custom_properties():
+    """Test modality registration with invalid custom properties."""
+    registry = ModalityRegistry()
+    with pytest.raises(ValueError):
+        registry.register_modality(
+            "modality_name_3", {"invalid_property": "invalid_value"}
+        )


### PR DESCRIPTION
# PR Type
Refactor, Fix.

# Short Description
Refactored modality object such that the `name` attribute (which is a string) can be used as keys in dictionaries across the code instead of a `Modality` object that subclasses `str`. Doing this prevents the `unexpected keys in state_dict` error when loading checkpoints. It also makes `torch.compile` comply.

# Tests Added
Added `tests/datasets/test_modality.py`
